### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ gifmaker
 
 A tool for extracting gifs from videos.
 
+Requirements:
+-------------
+
+You would need the commandline tool `avprobe` installed on your computer. It is a part of `libav` package. On OS X, you can install this with `brew install libav`.
+
 Sample Usage:
 -------------
 


### PR DESCRIPTION
Add instruction about required dependency of this project.

While it is clear that one can install this project by running `python setup.py install`, it is not explicit that the program itself depends on availability of a command line tool called `avprobe` (part of the libav package).